### PR TITLE
indent update

### DIFF
--- a/doc/roku.txt
+++ b/doc/roku.txt
@@ -69,6 +69,13 @@ g:roku_remove_old                                           *g:roku_remove_old*
 if not set, or set to 1, |RokuPackage| will overwrite old .pkg files - if set
 to 0, old .pkg files will be kept alongside the new ones.
 
+-----------------------------------------------------------------------------
+g:roku_indent_condcomp                                 *g:roku_indent_condcomp*
+
+if set to 1, conditional compilation statements (#if/#else/#end if) will
+trigger a change in indentation like the equivalent runtime if/else/end if
+statements. this behavior is disabled by default.
+
 =============================================================================
 COMMANDS & MAPPINGS                                             *roku-commands*
 
@@ -138,7 +145,9 @@ free to submit a PR, an issue, etc, at <https://github.com/entrez/roku.vim>.
 =============================================================================
 CHANGELOG                                                      *roku-changelog*
 
+v0.9.3 - Fixes a couple minor issues with filetype detection & syntax
+highlighting (2019-07-31)
 v0.9.2 - Fixes a bug which caused the plugin to hang when creating a new brs
-file in a non-existent directory (2019/07/18)
-v0.9.1 - Adds RokuGoToDef & refines some syntax highlighting (2019/07/18)
-v0.9.0 - Initial public release (2019/07/08)
+file in a non-existent directory (2019-07-18)
+v0.9.1 - Adds RokuGoToDef & refines some syntax highlighting (2019-07-18)
+v0.9.0 - Initial release (2019-07-08)


### PR DESCRIPTION
* change default indent behavior so that conditional compilation statements (`#if`, `#else`, `#end if`) no longer update indentation level
* tweak some other `indent/brs.vim` regex patterns
* add new option to re-enable that behavior: `g:roku_indent_condcomp`
* update documentation accordingly