### PR TITLE
multidevice deployment/packaging support

### DIFF
--- a/autoload/installpkg.vim
+++ b/autoload/installpkg.vim
@@ -12,12 +12,15 @@ func! installpkg#RokuInstall(...)
         return
     endif
 
-    let s:roku_ip = a:0 > 0 ? a:1 : g:roku_ip
+    let target_devices = a:0 > 0 ? a:000 : [ g:roku_ip ]
 
-    echoh Normal | echom 'compressing channel & uploading to roku (' . s:roku_ip . ')'
-    let s:result = split(system(s:path . 'install "' . bufname('%') . '" -u ' . g:roku_username . ':' . g:roku_password .
-                \ ' -d ' . s:roku_ip), '\n')
-    echom join(s:result)
+    for roku_ip in target_devices
+        echoh Normal | echom 'compressing channel & uploading to roku (' . roku_ip . ')'
+        let result = split(system(s:path . 'install "' . bufname('%') . 
+                    \ '" -u ' . g:roku_username . ':' . g:roku_password .
+                    \ ' -d ' . roku_ip), '\n')
+        echom join(result)
+    endfor
 endfunc
 
 func! installpkg#RokuPackage(...)
@@ -35,10 +38,15 @@ func! installpkg#RokuPackage(...)
         return
     endif
 
-    let s:roku_ip = a:0 > 0 ? a:1 : g:roku_ip
-    let s:remove = !exists('g:roku_remove_old') || g:roku_remove_old ? ' --remove-old ' : ' '
+    let target_devices = a:0 > 0 ? a:000 : [ g:roku_ip ]
+    let remove = !exists('g:roku_remove_old') || g:roku_remove_old ? ' --remove-old ' : ' '
 
-    echoh Normal | echom 'packaging channel'
-    let s:result = split(system('cd "' . fnamemodify(bufname("%"), ':p:h') . '" && ' . s:path . 'package' . s:remove . s:roku_ip . ' -u ' . g:roku_username . ':' . g:roku_password . ' -p ' . g:roku_pkg_pass))
-    echom join(s:result)
+    for roku_ip in target_devices
+        echoh Normal | echom 'packaging channel'
+        let result = split(system('cd "' . fnamemodify(bufname("%"), ':p:h') . '" && ' . s:path . 
+                    \ 'package' . remove . roku_ip . 
+                    \ ' -u ' . g:roku_username . ':' . g:roku_password . 
+                    \ ' -p ' . g:roku_pkg_pass))
+        echom join(result)
+    endfor
 endfunc

--- a/autoload/installpkg.vim
+++ b/autoload/installpkg.vim
@@ -12,7 +12,7 @@ func! installpkg#RokuInstall(...)
         return
     endif
 
-    let target_devices = a:0 > 0 ? a:000 : [ g:roku_ip ]
+    let target_devices = a:0 > 0 ? a:000 : type(g:roku_ip) == 3 ? g:roku_ip : [ g:roku_ip ]
 
     for roku_ip in target_devices
         echoh Normal | echom 'compressing channel & uploading to roku (' . roku_ip . ')'
@@ -38,7 +38,7 @@ func! installpkg#RokuPackage(...)
         return
     endif
 
-    let target_devices = a:0 > 0 ? a:000 : [ g:roku_ip ]
+    let target_devices = a:0 > 0 ? a:000 : type(g:roku_ip) == 3 ? g:roku_ip : [ g:roku_ip ]
     let remove = !exists('g:roku_remove_old') || g:roku_remove_old ? ' --remove-old ' : ' '
 
     for roku_ip in target_devices

--- a/autoload/installpkg.vim
+++ b/autoload/installpkg.vim
@@ -40,6 +40,7 @@ func! installpkg#RokuPackage(...)
 
     let target_devices = a:0 > 0 ? a:000 : type(g:roku_ip) == 3 ? g:roku_ip : [ g:roku_ip ]
     let remove = !exists('g:roku_remove_old') || g:roku_remove_old ? ' --remove-old ' : ' '
+    let target_devices = remove == ' ' ? target_devices : target_devices[:0]
 
     for roku_ip in target_devices
         echoh Normal | echom 'packaging channel'

--- a/doc/roku.txt
+++ b/doc/roku.txt
@@ -37,11 +37,18 @@ number of variables may be and/or should be defined.
 -----------------------------------------------------------------------------
 g:roku_ip                                                           *g:roku_ip*
 
-this can be set to the hostname or ip address of the device which is to be
-used by default, and is used when one of the |RokuInstall| or |RokuPackage|
-commands is called without specifying a device. if not set, either command
-may still be used by specifying the ip or hostname as the first (and only)
-argument - see |RokuInstall| and |RokuPackage| for more detail.
+this can be set to the hostname or ip address of the device(s) to be used by
+default, and is used when one of the |RokuInstall| or |RokuPackage| commands
+is called without specifying a device. if not set, either command may still
+be used by specifying any number of ips or hostnames as its only arguments -
+see |RokuInstall| and |RokuPackage| for more detail.
+
+to use a single device by default for installation & packaging, set g:roku_ip
+like so:
+    let g:roku_ip = '120.0.0.1'
+
+to deploy to multiple devices by default instead:
+    let g:roku_ip = ['120.0.0.1', '120.0.0.2', '120.0.0.3']
 
 -----------------------------------------------------------------------------
 g:roku_pkg_pass                                               *g:roku_pkg_pass*
@@ -111,17 +118,17 @@ addField("foo") function.
 -----------------------------------------------------------------------------
 RokuInstall                                                       *RokuInstall*
 
-usage: RokuInstall [IP/HOSTNAME]
+usage: RokuInstall [IP/HOSTNAME ...]
 default mapping: <leader>;
 
-install the current roku project/channel to the device specified - if no ip
-or hostname is included when calling the function, the value of |g:roku_ip|
+install the current roku project/channel to the device(s) specified - if no
+ip or hostname is included when calling the function, the value of |g:roku_ip|
 is used by default.
 
 -----------------------------------------------------------------------------
 RokuPackage                                                       *RokuPackage*
 
-usage: RokuPackage [IP/HOSTNAME]
+usage: RokuPackage [IP/HOSTNAME ...]
 default mapping: <leader>'
 
 package the current sideloaded channel on the device in question - if called
@@ -130,8 +137,10 @@ an out/ directory in the main project folder. otherwise, the .pkg file will
 be saved in the current directory.
 
 if |g:roku_remove_old| is set to 0, old .pkg files in the output directory
-will be kept - otherwise, any existing package files will be overwritten/
-removed when the new .pkg file is retrieved from the device.
+will be kept, and packages will be retrieved from all the specified devices;
+otherwise, any existing package files will be overwritten/removed when the
+new .pkg file is retrieved from the device, and only the first device named
+will be used.
 
 as with |RokuInstall|, if no ip or hostname is specified |g:roku_ip| will be
 used by default.

--- a/plugin/detectrokuproj.vim
+++ b/plugin/detectrokuproj.vim
@@ -6,8 +6,8 @@ augroup END
 fun! s:RokuCheck()
     if glob(fnamemodify(bufname('%'), ':p:h')) != ''
         if glob(fnamemodify(bufname('%'), ':p:h') . '/source/*.brs') != '' || glob(fnamemodify(bufname('%'), ':p:h') . '/*.brs') != ''
-            com! -nargs=? -buffer RokuInstall :call installpkg#RokuInstall(<args>)
-            com! -nargs=? -buffer RokuPackage :call installpkg#RokuPackage(<args>)
+            com! -nargs=* -buffer RokuInstall :call installpkg#RokuInstall(<f-args>)
+            com! -nargs=* -buffer RokuPackage :call installpkg#RokuPackage(<f-args>)
             nnoremap <buffer> <leader>; :RokuInstall<cr>
             nnoremap <buffer> <leader>' :RokuPackage<cr>
         else
@@ -18,8 +18,8 @@ fun! s:RokuCheck()
 
             if glob(fnamemodify(bufname('%'), s:steps) . '/source/*.brs') != '' &&
                         \ glob(fnamemodify(bufname('%'), s:steps) . '/manifest') != ''
-                com! -nargs=? -buffer RokuInstall :call installpkg#RokuInstall(<args>)
-                com! -nargs=? -buffer RokuPackage :call installpkg#RokuPackage(<args>)
+                com! -nargs=* -buffer RokuInstall :call installpkg#RokuInstall(<f-args>)
+                com! -nargs=* -buffer RokuPackage :call installpkg#RokuPackage(<f-args>)
                 nnoremap <buffer> <leader>; :RokuInstall<cr>
                 nnoremap <buffer> <leader>' :RokuPackage<cr>
             endif 

--- a/roku_scripts/install
+++ b/roku_scripts/install
@@ -94,22 +94,6 @@ if [ $? -eq 0 ]; then
     if ! curl -d '' "${ROKU_IP}:8060/keypress/home" &>/dev/null; then
         echo "no connection to roku (${ROKU_IP})"
         exit 1
-    else
-        case "${ROKU_IP}" in
-            10.192.7.104) # rokuexpress
-                # alternate format: curl -d '' '10.192.24.45:8060/keypress/InputHDMI1'
-                [[ "$(curl -s '10.192.24.45:8060/query/active-app' &2>/dev/null)" =~ '<app id="tvinput.hdmi1"' ]] || \
-                    (curl -d '' '10.192.24.45:8060/launch/tvinput.hdmi1' &>/dev/null; echo 'switching to input 1' >&2)
-                ;;
-            10.192.24.241) # roku3
-                [[ "$(curl -s '10.192.24.45:8060/query/active-app' &2>/dev/null)" =~ '<app id="tvinput.hdmi2"' ]] || \
-                    (curl -d '' '10.192.24.45:8060/launch/tvinput.hdmi2' &>/dev/null; echo 'switching to input 2' >&2)
-                ;;
-            10.192.7.93) # rokustick 
-                [[ "$(curl -s '10.192.24.45:8060/query/active-app' &2>/dev/null)" =~ '<app id="tvinput.hdmi3"' ]] || \
-                    (curl -d '' '10.192.24.45:8060/launch/tvinput.hdmi3' &>/dev/null; echo 'switching to input 3' >&2)
-                ;;
-        esac
     fi
 
     resp=$(curl -fLs -u "${ROKU_USER}:${ROKU_PASS}" --digest "${ROKU_IP}/plugin_install" \


### PR DESCRIPTION
* added support for specifying multiple devices as target of installation/packaging commands
* added support for defining multiple devices as default via `g:roku_ip`