### PR TITLE
roku remote control from in vim

### DIFF
--- a/autoload/communicate.vim
+++ b/autoload/communicate.vim
@@ -1,0 +1,33 @@
+let s:path = fnamemodify(resolve(expand('<sfile>:p')), ':h:h') . '/roku_scripts/'
+
+func! communicate#RokuMessage(...)
+    if !exists('g:roku_ip')
+        echoh ErrorMsg | echom 'roku: missing valid hostname or ip - set g:roku_ip'
+        return
+    elseif a:0 == 0
+        echoh ErrorMsg | echom 'roku: no message included - use RokuMsg <text>'
+        return
+    endif
+    let target_device = type(g:roku_ip) == 3 ? g:roku_ip[0] : g:roku_ip
+
+    let result = system(s:path . 'remote ' . target_device . ' -m ' . a:1)
+    if len(result) > 0
+        echoh ErrorMsg | echom s:result
+    endif
+endfunc
+
+func! communicate#RokuRemote(...)
+    if !exists('g:roku_ip')
+        echoh ErrorMsg | echom 'roku: missing valid hostname or ip - set g:roku_ip'
+        return
+    elseif a:0 == 0
+        echoh ErrorMsg | echom 'roku: no key name included - use RokuRemote <key>'
+        return
+    endif
+    let target_device = type(g:roku_ip) == 3 ? g:roku_ip[0] : g:roku_ip
+
+    let result = system(s:path . 'remote ' . target_device . ' -k ' . a:1)
+    if len(result) > 0
+        echoh ErrorMsg | echom s:result
+    endif
+endfunc

--- a/doc/roku.txt
+++ b/doc/roku.txt
@@ -50,6 +50,11 @@ like so:
 to deploy to multiple devices by default instead:
     let g:roku_ip = ['120.0.0.1', '120.0.0.2', '120.0.0.3']
 
+devices should be listed roughly in order of priority if g:roku_ip is set to
+a list of hostnames/ips: commands which target only one device at a time,
+like |RokuRemote|, will generally default to using the first value in the
+list.
+
 -----------------------------------------------------------------------------
 g:roku_pkg_pass                                               *g:roku_pkg_pass*
 
@@ -82,6 +87,27 @@ g:roku_indent_condcomp                                 *g:roku_indent_condcomp*
 if set to 1, conditional compilation statements (#if/#else/#end if) will
 trigger a change in indentation like the equivalent runtime if/else/end if
 statements. this behavior is disabled by default.
+
+-----------------------------------------------------------------------------
+g:roku_remote_keys                                         *g:roku_remote_keys*
+
+defines normal keymappings for triggering specific buttons with |RokuRemote|,
+but in such a way that they're only applied in roku project files where this
+plugin is active. compared to defining these mappings in a .vimrc file, for
+example, this ensures mappings are never set for commands when they aren't
+available & would cause an error.
+
+the format used should be a dictionary where remote button names (see list:
+|RokuKeynames|) are associated with their desired mappings, e.g.:
+
+        let g:roku_remote_keys = {
+            \ 'home': '<m-home>',
+            \ 'up': '<m-up>',
+            \ 'down': '<m-down>',
+            \ 'left': '<m-left>',
+            \ 'right': '<m-right>',
+            \ 'select': '<m-enter>',
+        \ }
 
 =============================================================================
 COMMANDS & MAPPINGS                                             *roku-commands*
@@ -144,6 +170,61 @@ will be used.
 
 as with |RokuInstall|, if no ip or hostname is specified |g:roku_ip| will be
 used by default.
+
+-----------------------------------------------------------------------------
+RokuMsg                                                               *RokuMsg*
+
+usage: RokuMsg <TEXT>
+default mapping: none
+
+send a string of text to the default device indicated by |g:roku_ip|, useful
+for things like search input, etc.
+
+-----------------------------------------------------------------------------
+RokuRemote                                                         *RokuRemote*
+
+usage: RokuMsg <KEY>
+default mapping: see |g:roku_remote_keys|
+
+simulate a keypress on the default device indicated by |g:roku_ip| via roku's
+ecp framework - this allows for direct interaction with your device without
+leaving the editor.
+
+                                                                 *RokuKeynames*
+the device will respond only to certain valid key names, listed below. some
+keys are non-standard - only supported by certain devices with advanced
+functionality, e.g. roku tvs - and are marked with an asterisk (*):
+
+            key name        description
+            --------        -----------
+            home            home button
+            rev             rewind button
+            fwd             fast-forward button
+            play            play/pause button
+            select          OK button
+            left            left arrow
+            right           right arrow
+            up              up arrow
+            down            down arrow
+            back            back button
+            instantreplay   instant replay/jump back button
+            info            options/* button
+            backspace       used in text input fields
+            search          submit search query
+            enter           submit input
+            findremote      activate `find my remote' feature*
+            volumedown      volume down button*
+            volumeup        volume up button*
+            volumemute      mute button*
+            poweroff        turn off device*
+            channelup       move up a channel (in tv tuner)*
+            channeldown     move down a channel (in tv tuner)*
+            inputtuner      switch to tv tuner*
+            inputhdmi1      change input to to hdmi1*
+            inputhdmi2      switch to hdmi2*
+            inputhdmi3      switch to hdmi3*
+            inputhdmi4      switch to hdmi4*
+            inputav1        switch to av1*
 
 =============================================================================
 CONTRIBUTING                                                     *roku-contrib*

--- a/plugin/detectrokuproj.vim
+++ b/plugin/detectrokuproj.vim
@@ -26,6 +26,13 @@ fun! s:RokuFileSetup()
     com! -nargs=* -buffer RokuPackage :call installpkg#RokuPackage(<f-args>)
     com! -nargs=1 -buffer RokuRemote :call communicate#RokuRemote(<q-args>)
     com! -nargs=1 -buffer RokuMsg :call communicate#RokuMessage(<q-args>)
+    if exists('g:roku_remote_keys')
+        for [key, mapping] in items(g:roku_remote_keys)
+            if mapping != ''
+                sil! exec 'nmap <silent> <buffer> ' . mapping . ' :RokuRemote ' . key . '<cr>'
+            endif
+        endfor
+    endif
     nnoremap <buffer> <leader>; :RokuInstall<cr>
     nnoremap <buffer> <leader>' :RokuPackage<cr>
 endfun

--- a/plugin/detectrokuproj.vim
+++ b/plugin/detectrokuproj.vim
@@ -1,6 +1,6 @@
 augroup roku_project_detect
     au!
-    au BufNewFile,BufRead manifest,translations.ts,*.brs,*.xml call s:RokuCheck() 
+    au bufnewfile,bufread manifest,translations.ts,*.brs,*.xml call s:RokuCheck() 
 augroup END
 
 fun! s:RokuCheck()
@@ -8,6 +8,8 @@ fun! s:RokuCheck()
         if glob(fnamemodify(bufname('%'), ':p:h') . '/source/*.brs') != '' || glob(fnamemodify(bufname('%'), ':p:h') . '/*.brs') != ''
             com! -nargs=* -buffer RokuInstall :call installpkg#RokuInstall(<f-args>)
             com! -nargs=* -buffer RokuPackage :call installpkg#RokuPackage(<f-args>)
+            com! -nargs=1 -buffer RokuRemote :call communicate#RokuRemote(<q-args>)
+            com! -nargs=1 -buffer RokuMsg :call communicate#RokuMessage(<q-args>)
             nnoremap <buffer> <leader>; :RokuInstall<cr>
             nnoremap <buffer> <leader>' :RokuPackage<cr>
         else
@@ -20,6 +22,8 @@ fun! s:RokuCheck()
                         \ glob(fnamemodify(bufname('%'), s:steps) . '/manifest') != ''
                 com! -nargs=* -buffer RokuInstall :call installpkg#RokuInstall(<f-args>)
                 com! -nargs=* -buffer RokuPackage :call installpkg#RokuPackage(<f-args>)
+                com! -nargs=1 -buffer RokuRemote :call communicate#RokuRemote(<q-args>)
+                com! -nargs=1 -buffer RokuMsg :call communicate#RokuMessage(<q-args>)
                 nnoremap <buffer> <leader>; :RokuInstall<cr>
                 nnoremap <buffer> <leader>' :RokuPackage<cr>
             endif 

--- a/plugin/detectrokuproj.vim
+++ b/plugin/detectrokuproj.vim
@@ -6,27 +6,26 @@ augroup END
 fun! s:RokuCheck()
     if glob(fnamemodify(bufname('%'), ':p:h')) != ''
         if glob(fnamemodify(bufname('%'), ':p:h') . '/source/*.brs') != '' || glob(fnamemodify(bufname('%'), ':p:h') . '/*.brs') != ''
-            com! -nargs=* -buffer RokuInstall :call installpkg#RokuInstall(<f-args>)
-            com! -nargs=* -buffer RokuPackage :call installpkg#RokuPackage(<f-args>)
-            com! -nargs=1 -buffer RokuRemote :call communicate#RokuRemote(<q-args>)
-            com! -nargs=1 -buffer RokuMsg :call communicate#RokuMessage(<q-args>)
-            nnoremap <buffer> <leader>; :RokuInstall<cr>
-            nnoremap <buffer> <leader>' :RokuPackage<cr>
+            call s:RokuFileSetup()
         else
-            let s:steps = ':p:h:h'
-            while glob(fnamemodify(bufname('%'), s:steps) . '/*') != glob('//*') && glob(fnamemodify(bufname('%'), s:steps) . '/manifest') == ''
-                let s:steps .= ':h'
+            let steps = ':p:h:h'
+            while glob(fnamemodify(bufname('%'), steps) . '/*') != glob('//*') && glob(fnamemodify(bufname('%'), steps) . '/manifest') == ''
+                let steps .= ':h'
             endwhile
 
-            if glob(fnamemodify(bufname('%'), s:steps) . '/source/*.brs') != '' &&
-                        \ glob(fnamemodify(bufname('%'), s:steps) . '/manifest') != ''
-                com! -nargs=* -buffer RokuInstall :call installpkg#RokuInstall(<f-args>)
-                com! -nargs=* -buffer RokuPackage :call installpkg#RokuPackage(<f-args>)
-                com! -nargs=1 -buffer RokuRemote :call communicate#RokuRemote(<q-args>)
-                com! -nargs=1 -buffer RokuMsg :call communicate#RokuMessage(<q-args>)
-                nnoremap <buffer> <leader>; :RokuInstall<cr>
-                nnoremap <buffer> <leader>' :RokuPackage<cr>
+            if glob(fnamemodify(bufname('%'), steps) . '/source/*.brs') != '' &&
+                        \ glob(fnamemodify(bufname('%'), steps) . '/manifest') != ''
+                call s:RokuFileSetup()
             endif 
         endif
     endif
+endfun
+
+fun! s:RokuFileSetup()
+    com! -nargs=* -buffer RokuInstall :call installpkg#RokuInstall(<f-args>)
+    com! -nargs=* -buffer RokuPackage :call installpkg#RokuPackage(<f-args>)
+    com! -nargs=1 -buffer RokuRemote :call communicate#RokuRemote(<q-args>)
+    com! -nargs=1 -buffer RokuMsg :call communicate#RokuMessage(<q-args>)
+    nnoremap <buffer> <leader>; :RokuInstall<cr>
+    nnoremap <buffer> <leader>' :RokuPackage<cr>
 endfun

--- a/roku_scripts/remote
+++ b/roku_scripts/remote
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+if [[ -z "${1}" || ! ("${@}" =~ '-k' || "${@}" =~ '-m') || $# -lt 2 ]]; then
+    echo "usage: remote [<device>] -k <key> | -m <message>"
+    exit 1
+fi
+
+if [[ "${1}" =~ ^-[km] ]]; then
+    op="${1}" 
+else
+    ROKU_IP="${1}"
+    op="${2}"
+fi
+
+[ -n "${ROKU_IP}" ] || ROKU_IP=""
+[[ -z "${ROKU_IP}" || "${ROKU_IP}" =~ ^([0-9a-fA-F]{4}:){7}[0-9a-fA-F]{4}$ || \
+    "${ROKU_IP}" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || \
+    ROKU_IP=$(cat /etc/hosts | awk "/${ROKU_IP//\//\\/}/ { print \$1 }")
+[ -z "${ROKU_IP}" ] && echo 'error: invalid hostname/ip' >&2 && exit 1
+
+msg=$(sed 's/^.*-[mk] *//' <<<"${@}")
+
+if [[ "${op}" == '-k' ]]; then
+    curl -s -d '' "${ROKU_IP}:8060/keypress/${msg}"
+else
+    len=${#msg}
+
+    for (( pos=0 ; pos<len ; pos++ )); do
+        c=${msg:$pos:1}
+        case "$c" in
+        [-_.~a-zA-Z0-9] ) o="${c}" ;;
+        * )               printf -v o '%%%02x' "'$c"
+        esac
+        curl -s -d '' "${ROKU_IP}:8060/keypress/Lit_${o}"
+    done
+fi


### PR DESCRIPTION
* added `:RokuRemote` command, which simulates keypress on default device (from `g:roku_ip`)
* added `:RokuMsg` command, which likewise sends string of text to default device
* added `g:roku_remote_keys`, a configurable way to map roku remote buttons to keyboard shortcuts so that they aren't set outside of roku projects where the command is accessible