### PR TITLE
resolve #11

### DIFF
--- a/roku_scripts/install
+++ b/roku_scripts/install
@@ -56,7 +56,11 @@ if [ ! -z "${CHANNEL_PATH}" ]; then
             echo "${CHANNEL_PATH} does not exist" >&2
             exit 1
         else
-            cd "${CHANNEL_PATH%/*}"
+            # without testing that ${CHANNEL_PATH%/*} and $CHANNEL_PATH are distinct locations, the script
+            # would fail when run on a file in the current directory via its relative path (i.e. just its
+            # filename) - see issue #11
+            [ "${CHANNEL_PATH}" != "${CHANNEL_PATH%/*}" ] && [ -e "${CHANNEL_PATH%/*}" ] \
+                && cd "${CHANNEL_PATH%/*}"
         fi
     fi
 fi


### PR DESCRIPTION
* ensure `${CHANNEL_PATH%/*}` is not the same as `${CHANNEL_PATH}` before trying to `cd` to it -- otherwise, when the filepath argument of `install` is just a filename in the current working directory, we end up trying to run `cd filename`. (resolve #11)